### PR TITLE
Without this we fail required field description in backend

### DIFF
--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -32,7 +32,10 @@ const RedisSessionStore = RedisSession(session);
 			const tournamentRepository = getRepository(Tournament);
 			const teamRepository = getRepository(Team);
 
-			let tournament = tournamentRepository.create({ name: 'My first tournament' });
+			const name = 'Cool Tournament';
+			const description = 'Very nice tournament with good description';
+			const game = 'League of Legends';
+			let tournament = tournamentRepository.create({ name, description, game });
 			tournament = await tournamentRepository.save(tournament);
 
 			const teams: Team[] = [];


### PR DESCRIPTION
The autogeneration of tournaments on backend required field description, this fixes it so we can generate.